### PR TITLE
Fix 500 bug when user try to send comment for course without graduate checkbox

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,7 +7,7 @@ module Users
 
       if current_user
         current_user.update_omniauth_data oauth_data
-        redirect_to :back
+        redirect_back fallback_location: root_path
       elsif @user.persisted?
         # this will throw if @user is not activated
         sign_in_and_redirect @user, event: :authentication

--- a/app/controllers/web/comments_controller.rb
+++ b/app/controllers/web/comments_controller.rb
@@ -20,7 +20,7 @@ module Web
           end
           format.json { render :show, status: 201, location: @comment }
         else
-          format.html { redirect_to :back, notice: @comment.errors.full_messages }
+          format.html { redirect_back fallback_location: root_path, notice: @comment.errors.full_messages.join("\n") }
           format.json { render json: @comment.errors.full_messages, status: 422 }
         end
       end


### PR DESCRIPTION
`redirect_to :back` was deprecated in Rails 5.0 (see [PR](https://github.com/rails/rails/pull/22506)) and then removed in Rails 5.1

Users had 500 error when comment without 'graduate' checkbox. In development environment:

```
NoMethodError (undefined method `back_url' for #<Web::CommentsController:0x00007f574f204498>
```